### PR TITLE
Make stop method public

### DIFF
--- a/copilot/instructions.md
+++ b/copilot/instructions.md
@@ -1,0 +1,10 @@
+For each change follow these tasks in sequence, showing the results for each task before moving to the next:
+    Task 1: Plan the changes based on the user request.
+        - Describe the goal and outline steps to achieve it.
+        - Provide a summary of the plan.
+        - Once complete, proceed to Task 2.
+    Task 2: Proceed with the implementation according to the latest plan.
+        - Implement the changes and provide the updated code for review.
+    Task 3: Recommendations if any new function were created. 
+        - Recommend to search for functions similar to the created ones with command like "@workspace search for function similar to {new function name}"
+        - Recommend if some existing functions will be found to use them in the requested changes with command like "Use the {found function name} in the requested changes"

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -7,6 +7,25 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.7</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
         <version>1.7.0</version>
@@ -59,7 +78,68 @@
       </plugin>
     </plugins>
   </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>4.0.0</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>byte-buddy</artifactId>
+          <groupId>net.bytebuddy</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>byte-buddy-agent</artifactId>
+          <groupId>net.bytebuddy</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>objenesis</artifactId>
+          <groupId>org.objenesis</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.8.2</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>junit-platform-engine</artifactId>
+          <groupId>org.junit.platform</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>apiguardian-api</artifactId>
+          <groupId>org.apiguardian</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.8.2</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>opentest4j</artifactId>
+          <groupId>org.opentest4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>junit-platform-commons</artifactId>
+          <groupId>org.junit.platform</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>apiguardian-api</artifactId>
+          <groupId>org.apiguardian</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
   <properties>
+    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
     <protobuf.version>3.19.1</protobuf.version>
     <protoc.plugin.version>1.44.0</protoc.plugin.version>
     <grpc.version>1.44.0</grpc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.example</groupId>
@@ -8,9 +9,35 @@
         <grpc.version>1.44.0</grpc.version>
         <protobuf.version>3.19.1</protobuf.version>
         <protoc.plugin.version>1.44.0</protoc.plugin.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.32</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
@@ -27,14 +54,33 @@
             <version>1.44.0</version>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>1.3.5</version>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.7</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- Add os-maven-plugin to detect OS specific settings -->
             <plugin>
                 <groupId>kr.motd.maven</groupId>
@@ -72,7 +118,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version> <!-- Ensure using a recent version -->
+                <version>3.2.4</version>
+                <!-- Ensure using a recent version -->
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -82,7 +129,8 @@
                         <configuration>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>my_service.MyServiceServer</mainClass> <!-- Replace with your main class -->
+                                    <mainClass>my_service.MyServiceServer</mainClass>
+                                    <!-- Replace with your main class -->
                                 </transformer>
                             </transformers>
                         </configuration>

--- a/src/main/java/my_service/MyServiceControllerImpl.java
+++ b/src/main/java/my_service/MyServiceControllerImpl.java
@@ -10,6 +10,8 @@ import java.time.format.DateTimeFormatter;
 
 public class MyServiceControllerImpl extends MyServiceControllerGrpc.MyServiceControllerImplBase {
 
+    private boolean status = false;
+
     @Override
     public void sayHello(Request request, StreamObserver<Response> responseObserver) {
         System.out.println("Received single message");
@@ -33,6 +35,9 @@ public class MyServiceControllerImpl extends MyServiceControllerGrpc.MyServiceCo
                 System.out.println(now + " Received message: " + request.getMessage());
                 for (int i = 0; i < request.getNumberOfTimes(); i++) {
                     System.out.println("Processing " + request.getMessage() + " time " + (i + 1));
+                    if (i == request.getNumberOfTimes() - 1) {
+                        status = true;
+                    }
                 }
 
                 try {
@@ -42,7 +47,7 @@ public class MyServiceControllerImpl extends MyServiceControllerGrpc.MyServiceCo
                 }
                 now = LocalDateTime.now().format(dtf);
                 System.out.println(now + " Sending response");
-                Response response = Response.newBuilder().setStatus(true).build();
+                Response response = Response.newBuilder().setStatus(status).build();
                 responseObserver.onNext(response);
             }
 

--- a/src/main/java/my_service/MyServiceServer.java
+++ b/src/main/java/my_service/MyServiceServer.java
@@ -17,12 +17,12 @@ public class MyServiceServer {
         System.out.println("Server started, listening on " + port);
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             System.err.println("*** shutting down gRPC server since JVM is shutting down");
-            MyServiceServer.this.stop();
+            stop();
             System.err.println("*** server shut down");
         }));
     }
 
-    private void stop() {
+    public void stop() {
         if (server != null) {
             server.shutdown();
         }

--- a/src/test/java/my_service/ProcessmessagingTest.java
+++ b/src/test/java/my_service/ProcessmessagingTest.java
@@ -1,0 +1,193 @@
+package my_service;
+
+import io.grpc.stub.StreamObserver;
+import my_service.Myproto.Request;
+import my_service.Myproto.Response;
+import org.mockito.ArgumentCaptor;
+import org.junit.jupiter.api.Test;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ProcessmessagingTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(ProcessmessagingTest.class);
+
+    // Process a single request and receive a response with status true
+    @Test
+    public void test_single_request_response_status_true() {
+        logger.info("Starting test_single_request_response_status_true");
+
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+        StreamObserver<Request> requestObserver = service.processMessaging(responseObserver);
+
+        Request request = Request.newBuilder().setMessage("Test").setNumberOfTimes(1).build();
+        requestObserver.onNext(request);
+
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(responseObserver).onNext(responseCaptor.capture());
+        Response response = responseCaptor.getValue();
+
+        assertTrue(response.getStatus());
+        logger.info("Ending test_single_request_response_status_true");
+    }
+
+    // Process multiple requests sequentially and receive responses with status true
+    @Test
+    public void test_multiple_requests_sequentially() {
+        logger.info("Starting test_multiple_requests_sequentially");
+
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+        StreamObserver<Request> requestObserver = service.processMessaging(responseObserver);
+
+        Request request1 = Request.newBuilder().setMessage("Test1").setNumberOfTimes(1).build();
+        Request request2 = Request.newBuilder().setMessage("Test2").setNumberOfTimes(2).build();
+        requestObserver.onNext(request1);
+        requestObserver.onNext(request2);
+
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(responseObserver, times(2)).onNext(responseCaptor.capture());
+        assertTrue(responseCaptor.getAllValues().get(0).getStatus());
+        assertTrue(responseCaptor.getAllValues().get(1).getStatus());
+
+        logger.info("Ending test_multiple_requests_sequentially");
+    }
+
+    // Log the received message with a timestamp
+    @Test
+    public void test_log_received_message_with_timestamp() {
+        logger.info("Starting test_log_received_message_with_timestamp");
+
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+        StreamObserver<Request> requestObserver = service.processMessaging(responseObserver);
+
+        Request request = Request.newBuilder().setMessage("Test").setNumberOfTimes(1).build();
+        requestObserver.onNext(request);
+
+        // Assuming we have a way to capture the logs, this is a placeholder for log verification
+        // verifyLogContains("Received message: Test");
+
+        logger.info("Ending test_log_received_message_with_timestamp");
+    }
+
+    // Log the processing of each message the specified number of times
+    @Test
+    public void test_log_processing_each_message_specified_times() {
+        logger.info("Starting test_log_processing_each_message_specified_times");
+
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+        StreamObserver<Request> requestObserver = service.processMessaging(responseObserver);
+
+        Request request = Request.newBuilder().setMessage("Test").setNumberOfTimes(3).build();
+        requestObserver.onNext(request);
+
+        // Assuming we have a way to capture the logs, this is a placeholder for log verification
+        // verifyLogContains("Processing Test time 1");
+        // verifyLogContains("Processing Test time 2");
+        // verifyLogContains("Processing Test time 3");
+
+        logger.info("Ending test_log_processing_each_message_specified_times");
+    }
+
+    // Send a response after processing the message
+    @Test
+    public void test_send_response_after_processing_message() {
+        logger.info("Starting test_send_response_after_processing_message");
+
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+        StreamObserver<Request> requestObserver = service.processMessaging(responseObserver);
+
+        Request request = Request.newBuilder().setMessage("Test").setNumberOfTimes(1).build();
+        requestObserver.onNext(request);
+
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(responseObserver, times(1)).onNext(responseCaptor.capture());
+        assertTrue(responseCaptor.getValue().getStatus());
+
+        logger.info("Ending test_send_response_after_processing_message");
+    }
+
+    // Handle an empty message in the request
+    @Test
+    public void test_handle_empty_message_in_request() {
+        logger.info("Starting test_handle_empty_message_in_request");
+
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+        StreamObserver<Request> requestObserver = service.processMessaging(responseObserver);
+
+        Request request = Request.newBuilder().setMessage("").setNumberOfTimes(1).build();
+        requestObserver.onNext(request);
+
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(responseObserver, times(1)).onNext(responseCaptor.capture());
+        assertTrue(responseCaptor.getValue().getStatus());
+
+        logger.info("Ending test_handle_empty_message_in_request");
+    }
+
+    // Handle a request with numberOfTimes set to zero
+    @Test
+    public void test_handle_request_with_number_of_times_zero() {
+        logger.info("Starting test_handle_request_with_number_of_times_zero");
+
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+        StreamObserver<Request> requestObserver = service.processMessaging(responseObserver);
+
+        Request request = Request.newBuilder().setMessage("Test").setNumberOfTimes(0).build();
+        requestObserver.onNext(request);
+
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(responseObserver, times(1)).onNext(responseCaptor.capture());
+        assertFalse(responseCaptor.getValue().getStatus());
+
+        logger.info("Ending test_handle_request_with_number_of_times_zero");
+    }
+
+    // Handle a request with a very large numberOfTimes
+    @Test
+    public void test_handle_request_with_large_number_of_times() {
+        logger.info("Starting test_handle_request_with_large_number_of_times");
+
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+        StreamObserver<Request> requestObserver = service.processMessaging(responseObserver);
+
+        Request request = Request.newBuilder().setMessage("Test").setNumberOfTimes(10000).build();
+        requestObserver.onNext(request);
+
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(responseObserver, times(1)).onNext(responseCaptor.capture());
+        assertTrue(responseCaptor.getValue().getStatus());
+
+        logger.info("Ending test_handle_request_with_large_number_of_times");
+    }
+
+        // Ensure the status is set to true only after the last iteration.
+    @Test
+    public void test_processmessaging_status_true_last_iteration() {
+        // Given
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+        StreamObserver<Request> requestObserver = service.processMessaging(responseObserver);
+        Request request = Request.newBuilder().setMessage("Test Message").setNumberOfTimes(3).build();
+
+        // When
+        requestObserver.onNext(request);
+
+        // Then
+        verify(responseObserver, times(1)).onNext(any(Response.class));
+        verify(responseObserver, times(1)).onCompleted();
+    }
+}

--- a/src/test/java/my_service/SayhelloTest.java
+++ b/src/test/java/my_service/SayhelloTest.java
@@ -1,0 +1,172 @@
+package my_service;
+
+import io.grpc.Server;
+import io.grpc.stub.StreamObserver;
+import my_service.MyServiceControllerImpl;
+import my_service.Myproto.Request;
+import my_service.Myproto.Response;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class SayhelloTest {
+
+    private static final Logger logger = Logger.getLogger(ProcessmessagingTest.class.getName());
+
+    // sayHello processes the request message correctly
+    @Test
+    public void test_processes_request_message_correctly() {
+        logger.info("Starting test_processes_request_message_correctly");
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        Request request = Request.newBuilder().setMessage("Hello").setNumberOfTimes(1).build();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+        service.sayHello(request, responseObserver);
+        verify(responseObserver).onNext(any(Response.class));
+        logger.info("Completed test_processes_request_message_correctly");
+    }
+
+    // sayHello iterates correct number of times
+    @Test
+    public void test_iterates_correct_number_of_times() {
+        logger.info("Starting test_iterates_correct_number_of_times");
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        Request request = Request.newBuilder().setMessage("Hello").setNumberOfTimes(3).build();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+        service.sayHello(request, responseObserver);
+        verify(responseObserver).onNext(any(Response.class));
+        verify(responseObserver, times(1)).onNext(any(Response.class));
+        verify(responseObserver, times(1)).onCompleted();
+        logger.info("Completed test_iterates_correct_number_of_times");
+    }
+
+    // sayHello constructs a response with status set to true
+    @Test
+    public void test_constructs_response_with_status_true() {
+        logger.info("Starting test_constructs_response_with_status_true");
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        Request request = Request.newBuilder().setMessage("Hello").setNumberOfTimes(1).build();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+        service.sayHello(request, responseObserver);
+        ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+        verify(responseObserver).onNext(captor.capture());
+        assertTrue(captor.getValue().getStatus());
+        logger.info("Completed test_constructs_response_with_status_true");
+    }
+
+    // sayHello sends the response using responseObserver.onNext
+    @Test
+    public void test_sends_response_using_onNext() {
+        logger.info("Starting test_sends_response_using_onNext");
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        Request request = Request.newBuilder().setMessage("Hello").setNumberOfTimes(1).build();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+        service.sayHello(request, responseObserver);
+        verify(responseObserver).onNext(any(Response.class));
+        logger.info("Completed test_sends_response_using_onNext");
+    }
+
+    // sayHello completes the response using responseObserver.onCompleted
+    @Test
+    public void test_completes_response_using_onCompleted() {
+        logger.info("Starting test_completes_response_using_onCompleted");
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        Request request = Request.newBuilder().setMessage("Hello").setNumberOfTimes(1).build();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+        service.sayHello(request, responseObserver);
+        verify(responseObserver).onCompleted();
+        logger.info("Completed test_completes_response_using_onCompleted");
+    }
+
+    // sayHello handles a request with count set to zero
+    @Test
+    public void test_handles_request_with_count_zero() {
+        logger.info("Starting test_handles_request_with_count_zero");
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        Request request = Request.newBuilder().setMessage("Hello").setNumberOfTimes(0).build();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+        service.sayHello(request, responseObserver);
+        verify(responseObserver).onNext(any(Response.class));
+        verify(responseObserver).onCompleted();
+        logger.info("Completed test_handles_request_with_count_zero");
+    }
+
+    // sayHello handles a request with an empty message
+    @Test
+    public void test_handles_request_with_empty_message() {
+        logger.info("Starting test_handles_request_with_empty_message");
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        Request request = Request.newBuilder().setMessage("").setNumberOfTimes(1).build();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+        service.sayHello(request, responseObserver);
+        verify(responseObserver).onNext(any(Response.class));
+        verify(responseObserver).onCompleted();
+        logger.info("Completed test_handles_request_with_empty_message");
+    }
+
+    // sayHello handles a request with a very large count
+    @Test
+    public void test_handles_request_with_large_count() {
+        logger.info("Starting test_handles_request_with_large_count");
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        Request request = Request.newBuilder().setMessage("Hello").setNumberOfTimes(10000).build();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+        service.sayHello(request, responseObserver);
+        verify(responseObserver).onNext(any(Response.class));
+        verify(responseObserver).onCompleted();
+        logger.info("Completed test_handles_request_with_large_count");
+    }
+
+    // sayHello handles a request with special characters in the message
+    @Test
+    public void test_handles_request_with_special_characters() {
+        logger.info("Starting test_handles_request_with_special_characters");
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        Request request = Request.newBuilder().setMessage("@#$%^&*()").setNumberOfTimes(1).build();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+        service.sayHello(request, responseObserver);
+        verify(responseObserver).onNext(any(Response.class));
+        verify(responseObserver).onCompleted();
+        logger.info("Completed test_handles_request_with_special_characters");
+    }
+
+    // sayHello handles a null request object
+    @Test
+    public void test_handles_null_request_object() {
+        logger.info("Starting test_handles_null_request_object");
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+    
+        assertThrows(NullPointerException.class, () -> {
+            service.sayHello(null, responseObserver);
+        });
+    
+        logger.info("Completed test_handles_null_request_object");
+    }
+
+    // sayHello ensures the log messages are in the correct order
+    @Test
+    public void test_logs_in_correct_order() {
+        logger.info("Starting test_logs_in_correct_order");
+    
+        // Mock gRPC server and service implementation
+        Server server = mock(Server.class);
+        MyServiceControllerImpl service = new MyServiceControllerImpl();
+    
+        Request request = Request.newBuilder().setMessage("Hello").setNumberOfTimes(2).build();
+        StreamObserver<Response> responseObserver = mock(StreamObserver.class);
+    
+        service.sayHello(request, responseObserver);
+    
+        InOrder inOrder = inOrder(responseObserver);
+        inOrder.verify(responseObserver).onNext(any(Response.class));
+        inOrder.verify(responseObserver).onCompleted();
+    
+        logger.info("Completed test_logs_in_correct_order");
+    }
+}


### PR DESCRIPTION
### **User description**
Changed the visibility of the stop method from private to public. This allows external classes to shut down the server when necessary.


___

### **PR Type**
enhancement


___

### **Description**
- Changed the visibility of the `stop` method from private to public in `MyServiceServer.java`.
- This change allows external classes to shut down the server when necessary.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MyServiceServer.java</strong><dd><code>Change `stop` method visibility to public for external access</code></dd></summary>
<hr>

src/main/java/my_service/MyServiceServer.java

<li>Changed the visibility of the <code>stop</code> method from private to public.<br> <li> Allows external classes to shut down the server.<br>


</details>


  </td>
  <td><a href="https://github.com/dashashamis1990/javaGRPCproject/pull/1/files#diff-a0ce900a10f5787bfcec54f5b74f5e83988af7e472b904a0ac75b81bae00a2c1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

